### PR TITLE
simplifies handling of Limited cards 

### DIFF
--- a/js/stores/cardStore.ts
+++ b/js/stores/cardStore.ts
@@ -80,13 +80,7 @@ class DeckStoreStatic implements IDeckStore {
 
 
   private addLimitedStatus(card:ICard){
-    if (card.hasOwnProperty('is_limited')){
-      //data is manually set, don't determine it now
-      return;
-    }
-    
-    var limitedRegex = new RegExp('<abbr>Limited<\\/abbr>.*', 'g');
-    card.is_limited = limitedRegex.test(card.text);
+    card.is_limited = card.text.includes('Limited.');
   }
 
   private addIncomeBonus(card:ICard){

--- a/js/stores/deckStore.ts
+++ b/js/stores/deckStore.ts
@@ -173,13 +173,7 @@ class DeckStoreStatic implements IDeckStore {
 
 
   private addLimitedStatus(card:ICard){
-    if (card.hasOwnProperty('is_limited')){
-      //data is manually set, don't determine it now
-      return;
-    }
-
-    var limitedRegex = new RegExp('<abbr>Limited<\\/abbr>.*', 'g');
-    card.is_limited = limitedRegex.test(card.text);
+    card.is_limited = card.text.includes('Limited.');
   }
 
   private addIncomeBonus(card:ICard){


### PR DESCRIPTION
currently, limited cards can be identified in two ways.

a) the card is declared as limited via the `is_limited` attribute in a JSON data file, found under `js/data`
b) while a given deck is being loaded, the card text is parsed for the "Limited" keyword, and if found the card object has its `is_limited` attribute set to `TRUE`.

method a) is reliable but required manual data massaging when new cards are added from TDB.
method b) is currently not working since the RegExp pattern used to parse the text assumes too much. 

this code change is proposing the removal of the hard-wired attribute from the data files altogether, and instead fixing method b). 

this will get us one step closer to importing cards data from the TDB API during the building process, rather than maintaining separate data in files in here. 